### PR TITLE
Support while loops in .xds

### DIFF
--- a/Objects/scripts/XDSScriptCompiler.swift
+++ b/Objects/scripts/XDSScriptCompiler.swift
@@ -461,11 +461,11 @@ class XDSScriptCompiler: NSObject {
 		if let file = XDSScriptCompiler.scriptFile {
 			let ext = file.fileExtension
 			switch ext {
-			case "xds": return evalTokensXDS(tokens: tokens, subExpr: false)
+			case "xds": return evalTokensXDS(tokens: tokens, subExpr: false)?.first
 			default:    break
 			}
 		}
-		return evalTokensXDS(tokens: tokens, subExpr: false)
+		return evalTokensXDS(tokens: tokens, subExpr: false)?.first
 	}
 
 	//MARK: - process the expressions
@@ -491,16 +491,14 @@ class XDSScriptCompiler: NSObject {
 				locations[name] = currentLocation
 			case .functionDefinition(let name, _):
 				locations[name] = currentLocation
-			case .ifStatement(let parts):
-				for (condition, block) in parts {
-					var SubCount = 0
-					for (loc, val) in getLocations(block) {
-						locations[loc] = val + currentLocation + condition.instructionCount + SubCount
-					}
-					SubCount += condition.instructionCount
-					for b in block {
-						SubCount += b.instructionCount
-					}
+			case .ifStatement(let condition, let block):
+				var SubCount = 0
+				for (loc, val) in getLocations(block) {
+					locations[loc] = val + currentLocation + condition.instructionCount + SubCount
+				}
+				SubCount += condition.instructionCount
+				for b in block {
+					SubCount += b.instructionCount
 				}
 			case .whileLoop(let condition, let block):
 				for (loc, val) in getLocations(block) {


### PR DESCRIPTION
- make `ifStatement` take only a single condition & body; more complex branching structures (i.e. if/else) can have their own cases
- let `evalTokensXDS` return an array to simplify while loop compilation as [.location, .ifStatement]
- parse while loops out of the instruction stack

looks like a lot of the guts (printing, instruction count, etc.) were there already from work you did before; I really just had to implement the patterns for compilation and decompilation

let me know if this looks reasonable to you