### PR TITLE
Remove objc interop codes from non View classes

### DIFF
--- a/Objects/data types/XGEvolution.swift
+++ b/Objects/data types/XGEvolution.swift
@@ -18,10 +18,10 @@ let kEvolvedFormOffset			= 0x4 // 2 bytes
 class XGEvolution: NSObject, Codable {
 	
 	var evolutionMethod		= XGEvolutionMethods.none
-	@objc var condition		= 0
-	@objc var evolvesInto		= 0
+	var condition		= 0
+	var evolvesInto		= 0
 	
-	@objc init(evolutionMethod: Int, condition: Int, evolvedForm: Int) {
+	init(evolutionMethod: Int, condition: Int, evolvedForm: Int) {
 		super.init()
 		
 		self.evolutionMethod = XGEvolutionMethods(rawValue: evolutionMethod)!
@@ -29,7 +29,7 @@ class XGEvolution: NSObject, Codable {
 		self.evolvesInto	 = evolvedForm
 	}
 	
-	@objc func isSet() -> Bool {
+	func isSet() -> Bool {
 		return self.evolutionMethod != .none
 	}
 	

--- a/Objects/data types/XGLevelUpMove.swift
+++ b/Objects/data types/XGLevelUpMove.swift
@@ -16,17 +16,17 @@ let kLevelUpMoveIndexOffset = 0x2 // 2 bytes
 
 class XGLevelUpMove: NSObject, Codable {
 	
-	@objc var level = 0x0
+	var level = 0x0
 	var move  = XGMoves.move(0)
 	
-	@objc init(level: Int, move: Int) {
+	init(level: Int, move: Int) {
 		super.init()
 		
 		self.level = level
 		self.move  = .move(move)
 	}
 	
-	@objc func isSet() -> Bool {
+	func isSet() -> Bool {
 		return self.level > 0
 	}
 	

--- a/Objects/data types/enumerable/CMTrainer.swift
+++ b/Objects/data types/enumerable/CMTrainer.swift
@@ -30,8 +30,8 @@ final class XGTrainer: NSObject, Codable {
 	
 	var index				= 0x0
 	
-	@objc var AI				= 0
-	@objc var cameraEffects		= 0 // xd only
+	var AI				= 0
+	var cameraEffects		= 0 // xd only
 	
 	var nameID				= 0x0
 	var preBattleTextID		= 0x0
@@ -42,7 +42,7 @@ final class XGTrainer: NSObject, Codable {
 	var trainerClass		= XGTrainerClasses.none
 	var trainerModel		= XGTrainerModels.wes
 	
-	@objc var battleData : XGBattle? {
+	var battleData : XGBattle? {
 		return nil
 	}
 	

--- a/Objects/data types/enumerable/XGBattleCD.swift
+++ b/Objects/data types/enumerable/XGBattleCD.swift
@@ -24,52 +24,52 @@ let kBattleCDConditionDescriptionIDOffset = 0x18
 final class XGBattleCD: NSObject, Codable {
 	
 	var battleStyle : XGBattleStyles!
-	@objc var battleField : XGBattleField!
+	var battleField : XGBattleField!
 	
 	var deck : XGDecks!
-	@objc var trainerID = 0
+	var trainerID = 0
 	var p1Deck : XGDecks!
-	@objc var p1TID = 0
+	var p1TID = 0
 	
-	@objc var turnLimit = 0
+	var turnLimit = 0
 	
-	@objc var index = 0
-	@objc var startOffset = 0
+	var index = 0
+	var startOffset = 0
 	
-	@objc var descriptionID = 0
-	@objc var cdDescription : XGString {
+	var descriptionID = 0
+	var cdDescription : XGString {
 		return getStringSafelyWithID(id: descriptionID)
 	}
 	
-	@objc var conditionsID = 0
-	@objc var conditions : XGString {
+	var conditionsID = 0
+	var conditions : XGString {
 		return getStringSafelyWithID(id: conditionsID)
 	}
 	
-	@objc var conditionsBoldID = 0
-	@objc var conditionsBold : XGString {
+	var conditionsBoldID = 0
+	var conditionsBold : XGString {
 		return getStringSafelyWithID(id: conditionsBoldID)
 	}
 	
-	@objc var trainer : XGTrainer? {
+	var trainer : XGTrainer? {
 		if deck == nil {
 			return nil
 		}
 		return XGTrainer(index: trainerID, deck: deck)
 	}
 	
-	@objc var p1Trainer : XGTrainer? {
+	var p1Trainer : XGTrainer? {
 		if p1Deck == nil {
 			return nil
 		}
 		return XGTrainer(index: p1TID, deck: p1Deck)
 	}
 	
-	@objc var rawData : [Int] {
+	var rawData : [Int] {
 		return XGFiles.common_rel.data!.getByteStreamFromOffset(self.startOffset, length: kSizeOfBattleCDData)
 	}
 	
-	@objc var title : String {
+	var title : String {
 		let p1t = p1Trainer
 		let p1 = p1t == nil ? (p1TID == 0x1388 ? "Player" : "Invalid") : p1t!.name.string
 		
@@ -117,7 +117,7 @@ final class XGBattleCD: NSObject, Codable {
 		return desc
 	}
 	
-	@objc init(index: Int) {
+	init(index: Int) {
 		super.init()
 		
 		self.index = index
@@ -150,7 +150,7 @@ final class XGBattleCD: NSObject, Codable {
 		
 	}
 	
-	@objc func save() {
+	func save() {
 		
 		let data = XGFiles.common_rel.data!
 		

--- a/Objects/data types/enumerable/XGInteractionPoint.swift
+++ b/Objects/data types/enumerable/XGInteractionPoint.swift
@@ -277,7 +277,7 @@ final class XGInteractionPointData: NSObject, Codable {
 		return desc
 	}
 	
-	@objc init(index: Int) {
+	init(index: Int) {
 		super.init()
 		
 		self.index = index
@@ -426,15 +426,15 @@ let kILZOffset = 0xC
 
 class XGMapEntryLocation : NSObject {
 	
-	@objc var index = 0
-	@objc var startOffset = 0
+	var index = 0
+	var startOffset = 0
 	
-	@objc var xCoordinate : Float = 0
-	@objc var yCoordinate : Float = 0
-	@objc var zCoordinate : Float = 0
-	@objc var angle = 0
+	var xCoordinate : Float = 0
+	var yCoordinate : Float = 0
+	var zCoordinate : Float = 0
+	var angle = 0
 	
-	@objc var room : XGRoom {
+	var room : XGRoom {
 		return XGRoom.roomWithName(self.file.fileName.removeFileExtensions())!
 	}
 	
@@ -456,7 +456,7 @@ class XGMapEntryLocation : NSObject {
 		
 	}
 	
-	@objc func save() {
+	func save() {
 		let data = file.data!
 		
 		data.replace2BytesAtOffset(startOffset + kIPAngleOffset, withBytes: self.angle)

--- a/Objects/data types/enumerable/XGPokeSpotPokemon.swift
+++ b/Objects/data types/enumerable/XGPokeSpotPokemon.swift
@@ -20,22 +20,22 @@ let kStepsPerPokeSnackOffset	= 0x0A
 
 final class XGPokeSpotPokemon: NSObject, Codable {
 	
-	@objc var index				= 0
+	var index				= 0
 	var spot					= XGPokeSpots.rock
 	var pokemon					= XGPokemon.pokemon(0)
 	
-	@objc var minLevel				= 0
-	@objc var maxLevel				= 0
-	@objc var encounterPercentage	= 0
-	@objc var stepsPerSnack			= 0
+	var minLevel				= 0
+	var maxLevel				= 0
+	var encounterPercentage	= 0
+	var stepsPerSnack			= 0
 
-	@objc var location : String {
+	var location : String {
 		get {
 			return spot.string
 		}
 	}
 	
-	@objc var startOffset : Int {
+	var startOffset : Int {
 		get {
 			return spot.commonRelIndex.startOffset + (index * kSizeOfPokeSpotData)
 		}
@@ -60,7 +60,7 @@ final class XGPokeSpotPokemon: NSObject, Codable {
 		
 	}
 	
-	@objc func save() {
+	func save() {
 		
 		let rel = XGFiles.common_rel.data!
 		let start = startOffset

--- a/Objects/data types/enumerable/XGPokemart.swift
+++ b/Objects/data types/enumerable/XGPokemart.swift
@@ -10,17 +10,17 @@ import Foundation
 
 final class XGPokemart: NSObject, Codable {
 	
-	@objc var index = 0
+	var index = 0
 	
 	var items = [XGItems]()
-	@objc var firstItemIndex = 0
-	@objc var itemsStartOffset : Int {
+	var firstItemIndex = 0
+	var itemsStartOffset : Int {
 		get {
 			return PocketIndexes.MartItems.startOffset + (firstItemIndex * 2)
 		}
 	}
 	
-	@objc init(index: Int) {
+	init(index: Int) {
 		super.init()
 		
 		let data = pocket.data!
@@ -37,7 +37,7 @@ final class XGPokemart: NSObject, Codable {
 		}
 	}
 	
-	@objc func save() {
+	func save() {
 		let data = pocket.data!
 		data.replace2BytesAtOffset(PocketIndexes.MartStartIndexes.startOffset + (index * 4) + 2, withBytes: self.firstItemIndex)
 		

--- a/Objects/data types/enumerable/XGStarterPokemon.swift
+++ b/Objects/data types/enumerable/XGStarterPokemon.swift
@@ -27,23 +27,23 @@ let kStarterExpValueOffset		= 0x66
 
 final class XGStarterPokemon: NSObject, XGGiftPokemon, Codable {
 	
-	@objc var level		= 0
-	@objc var exp		= 0
+	var level		= 0
+	var exp		= 0
 	var species			= XGPokemon.pokemon(0)
 	var move1			= XGMoves.move(0)
 	var move2			= XGMoves.move(0)
 	var move3			= XGMoves.move(0)
 	var move4			= XGMoves.move(0)
 	
-	@objc var giftType		= "Starter Pokemon"
+	var giftType		= "Starter Pokemon"
 	
 	// unused
-	@objc var index			= 0
+	var index			= 0
 	var shinyValue			= XGShinyValues.random
 	private(set) var gender	= XGGenders.random
 	private(set) var nature	= XGNatures.random
 		
-	@objc var startOffset : Int {
+	var startOffset : Int {
 		get {
 			return kEeveeStartOffset
 		}
@@ -74,7 +74,7 @@ final class XGStarterPokemon: NSObject, XGGiftPokemon, Codable {
 		}
 	}
 	
-	@objc func save() {
+	func save() {
 		
 		if game == .XD {
 			let dol = XGFiles.dol.data!

--- a/Objects/data types/enumerable/XGTrainerClass.swift
+++ b/Objects/data types/enumerable/XGTrainerClass.swift
@@ -18,24 +18,24 @@ let kTrainerClassNameIDOffset		= 0x04
 
 final class XGTrainerClass: NSObject, Codable {
 	
-	@objc var payout = 0
-	@objc var nameID = 0
+	var payout = 0
+	var nameID = 0
 	
 	var index = 0
 	
-	@objc var name : XGString {
+	var name : XGString {
 		get {
 			return XGFiles.common_rel.stringTable.stringSafelyWithID(self.nameID)
 		}
 	}
 	
-	@objc var startOffset : Int {
+	var startOffset : Int {
 		get {
 			return kFirstTrainerClassDataOffset + (self.index * kSizeOfTrainerClassEntry)
 		}
 	}
 	
-	@objc var dictionaryRepresentation : [String : AnyObject] {
+	var dictionaryRepresentation : [String : AnyObject] {
 		get {
 			var dictRep = [String : AnyObject]()
 			dictRep["name"] = self.name.string as AnyObject?
@@ -46,7 +46,7 @@ final class XGTrainerClass: NSObject, Codable {
 		}
 	}
 	
-	@objc var readableDictionaryRepresentation : [String : AnyObject] {
+	var readableDictionaryRepresentation : [String : AnyObject] {
 		get {
 			var dictRep = [String : AnyObject]()
 			dictRep["payout"] = self.payout as AnyObject?
@@ -70,7 +70,7 @@ final class XGTrainerClass: NSObject, Codable {
 		
 	}
 	
-	@objc func save() {
+	func save() {
 		
 		let rel = XGFiles.common_rel.data!
 		let start = self.startOffset

--- a/Objects/data types/enumerable/XGTrainerPokemon.swift
+++ b/Objects/data types/enumerable/XGTrainerPokemon.swift
@@ -51,16 +51,16 @@ final class XGTrainerPokemon : NSObject, Codable {
 	var deckData			= XGDeckPokemon.dpkm(0, XGDecks.DeckStory)
 	
 	var species				= XGPokemon.pokemon(0)
-	@objc var level			= 0x0
-	@objc var happiness		= 0x0
+	var level			= 0x0
+	var happiness		= 0x0
 	var item				= XGItems.item(0)
 	var nature				= XGNatures.hardy
 	var gender				= XGGenders.male
-	@objc var IVs			= 0x0 // All IVs will be the same. Not much point in varying them.
-	@objc var EVs			= [0,0,0,0,0,0]
+	var IVs			= 0x0 // All IVs will be the same. Not much point in varying them.
+	var EVs			= [0,0,0,0,0,0]
 	var moves				= [XGMoves](repeating: XGMoves.move(0), count: kNumberOfPokemonMoves)
 	
-	@objc var ability		= 0x0 {
+	var ability		= 0x0 {
 		didSet {
 			if ![0,1].contains(ability) {
 				ability = 0xFF // set to random in colosseum
@@ -68,41 +68,41 @@ final class XGTrainerPokemon : NSObject, Codable {
 		}
 	}
 	
-	@objc var shadowCatchRate 	= 0x0
-	@objc var shadowCounter		= 0x0
-	@objc var ShadowDataInUse 	= false
+	var shadowCatchRate 	= 0x0
+	var shadowCounter		= 0x0
+	var ShadowDataInUse 	= false
 	var shadowMoves				= [XGMoves](repeating: XGMoves.move(0), count: kNumberOfPokemonMoves)
-	@objc var shadowFleeValue 	= 0x0
+	var shadowFleeValue 	= 0x0
 	
-	@objc var shadowAggression = 0x0
-	@objc var shadowAlwaysFlee = 0x0
-	@objc var shadowBoostLevel = 0x0 // level before snagged
+	var shadowAggression = 0x0
+	var shadowAlwaysFlee = 0x0
+	var shadowBoostLevel = 0x0 // level before snagged
 	
-	@objc var priority1 = 0x0
+	var priority1 = 0x0
 	
 	// function of these bytes modified by editing dol code
 	var shinyness = XGShinyValues.never
-	@objc var priority	  = 0
+	var priority	  = 0
 	
-	@objc var startOffset : Int {
+	var startOffset : Int {
 		get {
 			return deckData.deck.DPKMDataOffset + (deckData.DPKMIndex * kSizeOfPokemonData)
 		}
 	}
 	
-	@objc var shadowStartOffset : Int {
+	var shadowStartOffset : Int {
 		get {
 			return XGDecks.DeckDarkPokemon.DDPKDataOffset + (deckData.index * kSizeOfShadowData)
 		}
 	}
 	
-	@objc var isShadowPokemon : Bool {
+	var isShadowPokemon : Bool {
 		get {
 			return deckData.isShadow
 		}
 	}
 	
-	@objc var isSet : Bool {
+	var isSet : Bool {
 		get {
 			return deckData.isSet
 		}
@@ -175,7 +175,7 @@ final class XGTrainerPokemon : NSObject, Codable {
 	}
 	
 	
-	@objc func save() {
+	func save() {
 		
 		if self.isShadowPokemon {
 			
@@ -233,7 +233,7 @@ final class XGTrainerPokemon : NSObject, Codable {
 		
 	}
 	
-	@objc func purge() {
+	func purge() {
 		species		= XGPokemon.pokemon(0)
 		level		= 0
 		happiness	= 0

--- a/Objects/helper data types/XGStack.swift
+++ b/Objects/helper data types/XGStack.swift
@@ -32,7 +32,7 @@ class XGStack<T>: NSObject {
 		return data.count
 	}
 	
-	@objc var isEmpty : Bool {
+	var isEmpty : Bool {
 		return data.count == 0
 	}
 }

--- a/Objects/scripts/XD/XGScriptInstruction.swift
+++ b/Objects/scripts/XD/XGScriptInstruction.swift
@@ -12,26 +12,26 @@ let kXDSLastResultVariable = "LastResult"
 
 class XGScriptInstruction: NSObject {
 	
-	@objc var isScriptFunctionLastResult = false // set during decompilation to prevent being attributed to the wrong function
-	@objc var isUnusedPostpendedCall = false // set during decompilation to prevent parsing stray function calls at end of script
+	var isScriptFunctionLastResult = false // set during decompilation to prevent being attributed to the wrong function
+	var isUnusedPostpendedCall = false // set during decompilation to prevent parsing stray function calls at end of script
 	
 	var opCode = XGScriptOps.nop
-	@objc var subOpCode = 0
-	@objc var parameter = 0
+	var subOpCode = 0
+	var parameter = 0
 	
-	@objc var longParameter = 0 // used by 'call', 'jumptrue', 'jumpfalse', and 'jump'
+	var longParameter = 0 // used by 'call', 'jumptrue', 'jumpfalse', and 'jump'
 	var subSubOpCodes = (0,0)
 	
-	@objc var level = 0
+	var level = 0
 	
-	@objc var length = 1
+	var length = 1
 	
-	@objc var raw1 : UInt32 = 0
-	@objc var raw2 : UInt32 = 0
+	var raw1 : UInt32 = 0
+	var raw2 : UInt32 = 0
 	
-	@objc var constant : XDSConstant!
+	var constant : XDSConstant!
 	
-	@objc var SCDVariable : String {
+	var SCDVariable : String {
 		let param = self.parameter
 		let (_, level) = self.subSubOpCodes
 		switch level {
@@ -72,7 +72,7 @@ class XGScriptInstruction: NSObject {
 		return self.isVariable && self.level == 3 && self.parameter >= 0x200
 	}
 	
-	@objc var XDSVariable : String {
+	var XDSVariable : String {
 		// add an asterisk to last result, local variables and script function parameters if the type of the varible isn't copyable.
 		// it is incredibly difficult to infer the underlying type for these variables.
 		
@@ -118,7 +118,7 @@ class XGScriptInstruction: NSObject {
 		return XDSVectorDimension(rawValue: d) ?? .invalid
 	}
 	
-	@objc init(bytes: UInt32, next: UInt32) {
+	init(bytes: UInt32, next: UInt32) {
 		super.init()
 		
 		let op				= ((bytes >> 24) & 0xFF).int

--- a/Objects/textures/XGColour.swift
+++ b/Objects/textures/XGColour.swift
@@ -12,13 +12,13 @@ class XGColour: NSObject, Codable {
 	
 	static var colourThreshold = 4
 	
-	@objc var red	= 0
-	@objc var green	= 0
-	@objc var blue	= 0
-	@objc var alpha	= 0
+	var red	= 0
+	var green	= 0
+	var blue	= 0
+	var alpha	= 0
 	
 	
-	@objc init(red: Int, green: Int, blue: Int, alpha: Int) {
+	init(red: Int, green: Int, blue: Int, alpha: Int) {
 		super.init()
 		
 		self.red   = red
@@ -66,23 +66,23 @@ class XGColour: NSObject, Codable {
 		}
 	}
 	
-	@objc var I4Representation : Int {
+	var I4Representation : Int {
 		return (red + green + blue) / (3 * 0x11)
 	}
 	
-	@objc var I8Representation : Int {
+	var I8Representation : Int {
 		return (red + green + blue) / 3
 	}
 	
-	@objc var IA4Representaion : Int {
+	var IA4Representaion : Int {
 		return ((alpha / 0x11) << 4) + (red + green + blue) / (3 * 0x11)
 	}
 	
-	@objc var IA8Representaion : Int {
+	var IA8Representaion : Int {
 		return (alpha << 8) + ((red + green + blue) / 3 )
 	}
 	
-	@objc var RGB565Representation : Int {
+	var RGB565Representation : Int {
 		get {
 			var value = 0
 			
@@ -94,7 +94,7 @@ class XGColour: NSObject, Codable {
 		}
 	}
 	
-	@objc var RGB5A3Representation : Int {
+	var RGB5A3Representation : Int {
 		get {
 			var value = 0
 			
@@ -114,7 +114,7 @@ class XGColour: NSObject, Codable {
 		}
 	}
 	
-	@objc var RGBA32Representation : [UInt8] {
+	var RGBA32Representation : [UInt8] {
 		return [alpha, red, green, blue].map({ (i) -> UInt8 in
 			return UInt8(i)
 		})
@@ -124,7 +124,7 @@ class XGColour: NSObject, Codable {
 		return (alpha << 24) + (red << 16) + (green << 8) + blue
 	}
 	
-	@objc class func none() -> XGColour {
+	class func none() -> XGColour {
 		return XGColour(red: 0, green: 0, blue: 0, alpha: 0)
 	}
 	
@@ -172,7 +172,7 @@ class XGColour: NSObject, Codable {
 		}
 	}
 	
-	@objc func setI4(raw: Int) {
+	func setI4(raw: Int) {
 		let value = raw * 0x11
 		self.red = value
 		self.green = value
@@ -180,14 +180,14 @@ class XGColour: NSObject, Codable {
 		self.alpha = 0xFF
 	}
 	
-	@objc func setI8(raw: Int) {
+	func setI8(raw: Int) {
 		self.red = raw
 		self.green = raw
 		self.blue = raw
 		self.alpha = 0xFF
 	}
 	
-	@objc func setIA4(raw: Int) {
+	func setIA4(raw: Int) {
 		let value = (raw % 16) * 0x11
 		self.red = value
 		self.green = value
@@ -195,7 +195,7 @@ class XGColour: NSObject, Codable {
 		self.alpha = (raw >> 4) * 0x11
 	}
 	
-	@objc func setIA8(raw: Int) {
+	func setIA8(raw: Int) {
 		let value = (raw % 256)
 		self.red = value
 		self.green = value
@@ -203,7 +203,7 @@ class XGColour: NSObject, Codable {
 		self.alpha = (raw >> 8)
 	}
 	
-	@objc func setRGB565(raw: Int) {
+	func setRGB565(raw: Int) {
 		var currentColour = raw
 		
 		self.blue = (currentColour % 0x20) * 8
@@ -217,7 +217,7 @@ class XGColour: NSObject, Codable {
 		self.alpha = 0xFF
 	}
 	
-	@objc func setRGB5A3(raw: Int) {
+	func setRGB5A3(raw: Int) {
 		
 		let top = raw >> 15
 		
@@ -250,7 +250,7 @@ class XGColour: NSObject, Codable {
 		
 	}
 	
-	@objc func setRGBA32(raw: UInt32) {
+	func setRGBA32(raw: UInt32) {
 		
 		self.alpha   = ((raw >> 24) & 0xFF).int32
 		self.red = ((raw >> 16) & 0xFF).int32

--- a/Revolution Tool CL/objects/PBRConstant.swift
+++ b/Revolution Tool CL/objects/PBRConstant.swift
@@ -77,21 +77,21 @@ enum XDSConstantTypes {
 class XDSConstant : NSObject {
 	
 	var type   : XDSConstantTypes = .none_t
-	@objc var value  : UInt32 = 0
+	var value  : UInt32 = 0
 	
 	override var description: String {
 		return self.rawValueString
 	}
 	
-	@objc var asFloat : Float {
+	var asFloat : Float {
 		return value.hexToSignedFloat()
 	}
 	
-	@objc var asInt : Int {
+	var asInt : Int {
 		return value.int32
 	}
 	
-	@objc var rawValueString : String {
+	var rawValueString : String {
 		switch self.type {
 		case .float:
 			var text = String(format: "%.4f", self.asFloat)
@@ -122,7 +122,7 @@ class XDSConstant : NSObject {
 		}
 	}
 	
-	@objc init(type: Int, rawValue: UInt32) {
+	init(type: Int, rawValue: UInt32) {
 		super.init()
 		
 		self.type = XDSConstantTypes.typeWithIndex(type)
@@ -134,7 +134,7 @@ class XDSConstant : NSObject {
 		self.init(type: type.index, rawValue: rawValue.unsigned)
 	}
 	
-	@objc class var null : XDSConstant {
+	class var null : XDSConstant {
 		return XDSConstant(type: 0, rawValue: 0)
 	}
 	

--- a/Revolution Tool CL/objects/PBRItem.swift
+++ b/Revolution Tool CL/objects/PBRItem.swift
@@ -35,19 +35,19 @@ final class XGItem: NSObject, XGIndexedValue, Codable {
 	
 	var friendshipEffects	= [0, 0, 0]
 	
-	@objc var name : XGString {
+	var name : XGString {
 		get {
 			return getStringSafelyWithID(id: nameID)
 		}
 	}
 	
-	@objc var descriptionString : XGString {
+	var descriptionString : XGString {
 		get {
 			return getStringSafelyWithID(id: descriptionID)
 		}
 	}
 	
-	@objc init(index: Int) {
+	init(index: Int) {
 		super.init()
 		
 		self.index = index
@@ -70,7 +70,7 @@ final class XGItem: NSObject, XGIndexedValue, Codable {
 		friendshipEffects = [data.getSignedByte(35), data.getSignedByte(36), data.getSignedByte(37)]
 	}
 	
-	@objc func save() {
+	func save() {
 		
 		let data  = PBRDataTableEntry.items(index: self.index)
 		

--- a/Revolution Tool CL/objects/PBRMove.swift
+++ b/Revolution Tool CL/objects/PBRMove.swift
@@ -63,20 +63,20 @@ final class XGMove: NSObject, XGIndexedValue {
 		return false
 	}
 	
-	@objc var name : XGString {
+	var name : XGString {
 		get {
 			return getStringSafelyWithID(id: nameID)
 		}
 	}
 	
-	@objc var mdescription : XGString {
+	var mdescription : XGString {
 		get {
 			return getStringSafelyWithID(id: descriptionID)
 		}
 	}
 	
 	
-	@objc init(index: Int) {
+	init(index: Int) {
 		super.init()
 		
 		self.index = index
@@ -119,7 +119,7 @@ final class XGMove: NSObject, XGIndexedValue {
 
 	}
 
-	@objc func save() {
+	func save() {
 		guard index >= 0 else { return }
 
 		let data  = PBRDataTableEntry.moves(index: index)

--- a/Revolution Tool CL/objects/PBRPokemonStats.swift
+++ b/Revolution Tool CL/objects/PBRPokemonStats.swift
@@ -117,13 +117,13 @@ final class XGPokemonStats: NSObject, XGIndexedValue {
 		return list
 	}
 	
-	@objc var name : XGString {
+	var name : XGString {
 		get {
 			return getStringSafelyWithID(id: nameID)
 		}
 	}
 	
-	@objc var species : XGString {
+	var species : XGString {
 		get {
 			return getStringSafelyWithID(id: speciesNameID)
 		}
@@ -214,7 +214,7 @@ final class XGPokemonStats: NSObject, XGIndexedValue {
 		}
 	}
 	
-	@objc func save() {
+	func save() {
 		
 		let data = PBRDataTableEntry.baseStats(index: self.index)
 		

--- a/Revolution Tool CL/objects/PBRScriptInstruction.swift
+++ b/Revolution Tool CL/objects/PBRScriptInstruction.swift
@@ -11,26 +11,26 @@ let kXDSLastResultVariable = "LastResult"
 
 class XGScriptInstruction: NSObject {
 	
-	@objc var isScriptFunctionLastResult = false // set during decompilation to prevent being attributed to the wrong function
-	@objc var isUnusedPostpendedCall = false // set during decompilation to prevent parsing stray function calls at end of script
+	var isScriptFunctionLastResult = false // set during decompilation to prevent being attributed to the wrong function
+	var isUnusedPostpendedCall = false // set during decompilation to prevent parsing stray function calls at end of script
 	
 	var opCode = XGScriptOps.nop
-	@objc var subOpCode = 0
-	@objc var parameter = 0
+	var subOpCode = 0
+	var parameter = 0
 	
-	@objc var longParameter = 0 // used by 'call', 'jumptrue', 'jumpfalse', and 'jump'
+	var longParameter = 0 // used by 'call', 'jumptrue', 'jumpfalse', and 'jump'
 	var subSubOpCodes = (0,0)
 	
-	@objc var level = 0
+	var level = 0
 	
-	@objc var length = 1
+	var length = 1
 	
-	@objc var raw1 : UInt32 = 0
-	@objc var raw2 : UInt32 = 0
+	var raw1 : UInt32 = 0
+	var raw2 : UInt32 = 0
 	
-	@objc var constant : XDSConstant!
+	var constant : XDSConstant!
 	
-	@objc var SCDVariable : String {
+	var SCDVariable : String {
 		let param = self.parameter
 		let (_, level) = self.subSubOpCodes
 		switch level {
@@ -53,7 +53,7 @@ class XGScriptInstruction: NSObject {
 		}
 	}
 	
-	@objc var XDSVariable : String {
+	var XDSVariable : String {
 		// add an asterisk to last result, local variables and script function parameters if the type of the varible isn't copyable.
 		// it is incredibly difficult to infer the underlying type for these variables.
 		
@@ -106,7 +106,7 @@ class XGScriptInstruction: NSObject {
 		return XDSVectorDimension(rawValue: d) ?? .invalid
 	}
 	
-	@objc init(bytes: UInt32, next: UInt32) {
+	init(bytes: UInt32, next: UInt32) {
 		super.init()
 		
 		let op				= ((bytes >> 24) & 0xFF).int

--- a/Revolution Tool CL/objects/PBRTrainer.swift
+++ b/Revolution Tool CL/objects/PBRTrainer.swift
@@ -38,7 +38,7 @@ class XGTrainer: NSObject, XGIndexedValue {
 		}
 	}
 	
-	@objc var name : XGString {
+	var name : XGString {
 		get {
 			return getStringSafelyWithID(id: nameID)
 		}
@@ -61,7 +61,7 @@ class XGTrainer: NSObject, XGIndexedValue {
 
 	}
 	
-	@objc func save() {
+	func save() {
 		
 	}
    

--- a/Revolution Tool CL/objects/PBRType.swift
+++ b/Revolution Tool CL/objects/PBRType.swift
@@ -45,7 +45,7 @@ final class XGType: NSObject, XGIndexedValue, Codable {
 		return effectivenessTable[type.index]
 	}
 	
-	@objc init(index: Int) {
+	init(index: Int) {
 		super.init()
 		
 		self.index = index
@@ -57,7 +57,7 @@ final class XGType: NSObject, XGIndexedValue, Codable {
 		
 	}
 	
-	@objc func save() {
+	func save() {
 		guard PBRTypeManager.updateTypeMatchupDolData(allowSizeIncrease: false) else {
 			displayAlert(title: "Failed to save type", description: "Couldn't save type match data. The number of non neutral matchups is too large for the data table. Try applying the patch to move the table.")
 			return


### PR DESCRIPTION
This removes the `@objc` decorator from classes that do not need it. This also fixes an issue in the latest Swift 5.3-dev snapshot for Windows that disables objc interop all-together.